### PR TITLE
[Bug] links to Readme.md and Readme_CN.md are still enabled in their pages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 <div align="center">
 
-[English](README.md) | [简体中文](https://github.com/mini-sora/minisora/blob/main/README_CN.md)  
+English | [简体中文](https://github.com/mini-sora/minisora/blob/main/README_CN.md)  
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 <div align="center">
 
-English | [简体中文](https://github.com/mini-sora/minisora/blob/main/README_CN.md)  
+English | [简体中文](README_CN.md)  
 
 </div>
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -20,7 +20,7 @@
 
 <div align="center">
 
-[English](README.md) | [简体中文](https://github.com/mini-sora/minisora/blob/main/README_CN.md)  
+[English](README.md) | 简体中文  
 
 
 </div>


### PR DESCRIPTION
## Pull Request Description

### Title
[Update] - links to Readme.md and Readme_CN.md are still enabled in their pages.
### Changes
- Modify the links to Readme.md and Readme_CN.md
