### PR TITLE
[docs]Add ACL 2023 paper link to LAVIS resource documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Please scan the QR code with WeChat to book a live video session.
 | 15) Text-to-Image Diffusion Models in Generative AI: A Survey | [**Paper**](http://arxiv.org/abs/2303.07909) |
 | 16) Awesome-Diffusion-Transformers | [GitHub](https://github.com/ShoufaChen/Awesome-Diffusion-Transformers), [Page](https://www.shoufachen.com/Awesome-Diffusion-Transformers/) |
 | 17) Open-Sora (HPC-AI Tech) |  [GitHub](https://github.com/hpcaitech/Open-Sora), [Blog](https://hpc-ai.com/blog/open-sora) |
-| 18) **LAVIS** - A Library for Language-Vision Intelligence | [GitHub](https://github.com/salesforce/lavis), [Page](https://opensource.salesforce.com/LAVIS//latest/index.html) |
+| 18) **LAVIS** - A Library for Language-Vision Intelligence | [**ACL 23 Paper**](https://aclanthology.org/2023.acl-demo.3.pdf), [GitHub](https://github.com/salesforce/lavis), [Page](https://opensource.salesforce.com/LAVIS//latest/index.html) |
 
 
 ## Mini Sora WeChat Community Exchange Group

--- a/README.md
+++ b/README.md
@@ -258,9 +258,9 @@ Please scan the QR code with WeChat to book a live video session.
 | 13) On the Design Fundamentals of Diffusion Models: A Survey | [**Paper**](http://arxiv.org/abs/2306.04542) |
 | 14) Efficient Diffusion Models for Vision: A Survey | [**Paper**](http://arxiv.org/abs/2210.09292) |
 | 15) Text-to-Image Diffusion Models in Generative AI: A Survey | [**Paper**](http://arxiv.org/abs/2303.07909) |
-| 16) Awesome-Diffusion-Transformers | [GitHub](https://github.com/ShoufaChen/Awesome-Diffusion-Transformers), [Page](https://www.shoufachen.com/Awesome-Diffusion-Transformers/) |
+| 16) Awesome-Diffusion-Transformers | [GitHub](https://github.com/ShoufaChen/Awesome-Diffusion-Transformers), [Project](https://www.shoufachen.com/Awesome-Diffusion-Transformers/) |
 | 17) Open-Sora (HPC-AI Tech) |  [GitHub](https://github.com/hpcaitech/Open-Sora), [Blog](https://hpc-ai.com/blog/open-sora) |
-| 18) **LAVIS** - A Library for Language-Vision Intelligence | [**ACL 23 Paper**](https://aclanthology.org/2023.acl-demo.3.pdf), [GitHub](https://github.com/salesforce/lavis), [Page](https://opensource.salesforce.com/LAVIS//latest/index.html) |
+| 18) **LAVIS** - A Library for Language-Vision Intelligence | [**ACL 23 Paper**](https://aclanthology.org/2023.acl-demo.3.pdf), [GitHub](https://github.com/salesforce/lavis), [Project](https://opensource.salesforce.com/LAVIS//latest/index.html) |
 
 
 ## Mini Sora WeChat Community Exchange Group

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -259,7 +259,7 @@ Mini Sora 开源社区定位为由社区同学自发组织的开源社区（**�
 | 15) Text-to-Image Diffusion Models in Generative AI: A Survey | [**Paper**](http://arxiv.org/abs/2303.07909) |
 | 16) Awesome-Diffusion-Transformers | [GitHub](https://github.com/ShoufaChen/Awesome-Diffusion-Transformers), [Page](https://www.shoufachen.com/Awesome-Diffusion-Transformers/) |
 | 17) Open-Sora (HPC-AI Tech) |  [GitHub](https://github.com/hpcaitech/Open-Sora), [Blog](https://hpc-ai.com/blog/open-sora) |
-| 18) **LAVIS** - A Library for Language-Vision Intelligence | [GitHub](https://github.com/salesforce/lavis), [Page](https://opensource.salesforce.com/LAVIS//latest/index.html) |
+| 18) **LAVIS** - A Library for Language-Vision Intelligence | [**ACL 23 Paper**](https://aclanthology.org/2023.acl-demo.3.pdf), [GitHub](https://github.com/salesforce/lavis), [Page](https://opensource.salesforce.com/LAVIS//latest/index.html) |
 
 ## Mini Sora 微信社区社区交流群
 


### PR DESCRIPTION
## Pull Request Description

Please read [CONTRIBUTING](https://github.com/mini-sora/minisora/blob/main/.github/CONTRIBUTING.md) manual before submitting your PR.

### Summary
This pull request adds information about the LAVIS paper to the README file. 

### Changes
- Added the links to the LAVIS paper. 
- Ensured that the links are functional and the information is up-to-date.

### Review Notes
- Please review the added content for accuracy and formatting.
- Check that the links provided are correct and lead to the intended resources.
- Please note that I have directly used the ACL 2023 link instead of the arXiv one. This is because the ACL 2023 link is already open access, and the content is almost identical in length. However, the published ACL paper is certainly more formal than preprint ver.
- **Please check if both the Chinese and English READMEs have been updated simultaneously.**

### Related Issues
- Closes #251 

### Additional Comments
- The addition of LAVIS to our README will provide valuable resources for users interested in language-vision research and applications.
